### PR TITLE
Add entry points to parsers

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        uv pip install -e '.[dev]'
+        uv pip install -e '.[dev,parsers]'
     - name: mypy
       run: |
         python -m mypy --ignore-missing-imports --follow-imports=silent --no-strict-optional openbis_upload_helper tests

--- a/openbis_upload_helper/uploader/entry_points/__init__.py
+++ b/openbis_upload_helper/uploader/entry_points/__init__.py
@@ -1,0 +1,1 @@
+from .load import get_entry_point_parsers

--- a/openbis_upload_helper/uploader/entry_points/load.py
+++ b/openbis_upload_helper/uploader/entry_points/load.py
@@ -6,9 +6,13 @@ def get_entry_point_parsers() -> dict[str, dict]:
     Get all parsers by loading their entry points as defined in the `bam.parsers` group of each individual parser package.
 
     Returns:
-        dict[str, dict]: A dictionary where keys are parser names and values are the loaded parser functions.
+        dict[str, dict]: A dictionary whose keys are parser names and values are dictionaries containing parser
+            metadata (e.g., name, description, parser_class).
     """
     parsers = {}
     for entry_point in importlib.metadata.entry_points(group="bam.parsers"):
-        parsers[entry_point.name] = entry_point.load()
+        try:
+            parsers[entry_point.name] = entry_point.load()
+        except Exception as e:
+            raise RuntimeError(f"Failed to load entry point '{entry_point.name}': {e}")
     return parsers

--- a/openbis_upload_helper/uploader/entry_points/load.py
+++ b/openbis_upload_helper/uploader/entry_points/load.py
@@ -1,0 +1,14 @@
+import importlib.metadata
+
+
+def get_entry_point_parsers() -> dict[str, dict]:
+    """
+    Get all parsers by loading their entry points as defined in the `bam.parsers` group of each individual parser package.
+
+    Returns:
+        dict[str, dict]: A dictionary where keys are parser names and values are the loaded parser functions.
+    """
+    parsers = {}
+    for entry_point in importlib.metadata.entry_points(group="bam.parsers"):
+        parsers[entry_point.name] = entry_point.load()
+    return parsers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   "pybis~=1.37.1rc4",
   "cryptography>=45.0.2",
   "python-decouple",
-  "nmrglue",
 ]
 
 [project.urls]
@@ -50,6 +49,9 @@ dev = [
   "pytest-timeout",
   "pytest-cov",
   "structlog==24.4.0",
+]
+parsers = [
+  "masterdata-parser-example@git+https://github.com/BAMresearch/masterdata-parser-example.git@main",
 ]
 
 [tool.ruff]

--- a/tests/entry_points/test_load.py
+++ b/tests/entry_points/test_load.py
@@ -1,0 +1,16 @@
+from openbis_upload_helper.uploader.entry_points import get_entry_point_parsers
+
+
+def test_get_entry_point_parsers():
+    parsers = get_entry_point_parsers()
+    assert isinstance(parsers, dict)
+    assert "masterdata_parser_example_entry_point" in parsers
+    assert (
+        parsers["masterdata_parser_example_entry_point"]["name"]
+        == "MasterdataParserExample"
+    )
+    assert (
+        parsers["masterdata_parser_example_entry_point"]["description"]
+        == "An example parser for masterdata."
+    )
+    assert "parser_class" in parsers["masterdata_parser_example_entry_point"]


### PR DESCRIPTION
@LucasZimm I think the changes are clear. You can see that you can simply do `available_parsers = get_entry_points_parsers()` to get a list of dictionaries containing the parser class with the parse function.

The question here is at which point of the app to have these loaded. It cannot be that everytime someone logs in, the parsers are loaded, but rather the app should have them in memory.

I am sure Jorg can help here and tell us what is the best practice :)